### PR TITLE
refactor type to interface for QueryMeta and MutationMeta

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -48,7 +48,9 @@ export interface InfiniteData<TData> {
   pageParams: unknown[]
 }
 
-export type QueryMeta = Record<string, unknown>
+export interface QueryMeta {
+  [index: string]: unknown
+}
 
 export interface QueryOptions<
   TQueryFnData = unknown,
@@ -527,7 +529,9 @@ export type MutationKey = string | readonly unknown[]
 
 export type MutationStatus = 'idle' | 'loading' | 'success' | 'error'
 
-export type MutationMeta = Record<string, unknown>
+export interface MutationMeta {
+  [index: string]: unknown
+}
 
 export type MutationFunction<TData = unknown, TVariables = unknown> = (
   variables: TVariables


### PR DESCRIPTION
Changes the QueryMeta and MutationMeta types to interfaces, so that they can have their shapes overridden in the implementing codebase for safer typing and autocompletion.

```
interface Meta {
  persist?: boolean;
}

declare module '@tanstack/react-query' {
  interface QueryMeta extends Meta {}
}
```

```
useQuery(queryKey, {
  meta: {
    persist: false,
  },
});
```